### PR TITLE
Fix addtionMarkdownModules

### DIFF
--- a/src/VueMarkdown.js
+++ b/src/VueMarkdown.js
@@ -163,7 +163,7 @@ export default {
     },
     addtionMarkdownModules: {
       type: Array,
-      default: [],
+      default: () => ([]),
     },
   },
 


### PR DESCRIPTION
[Vue warn]: Invalid default value for prop "addtionMarkdownModules": Props with type Object/Array must use a factory function to return the default value.